### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "urls": [
+    ["ADS1115.py", "github:robert-hh/Micropython_ADS1115/ADS1115.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
This PR adds a package.json file to make the module compatible with the MicroPython Package Manager (MIP).

With this change, users can install the module using: \

This PR is part of an effort to add package.json to popular MicroPython libraries.